### PR TITLE
Single model routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export default Route.extend({
     modelName: 'user',
     beforeModel() {
         this._super(...arguments);
-        ...othercode
+        //...your code
     },
     model() {
         const query = {
@@ -42,7 +42,7 @@ export default Route.extend({
     },
     afterModel() {
         this._super(...arguments);
-        ...othercode
+        //...your code
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-fastboot-route",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "This addon serializes the route data for each route in the chain when running in Fastboot. Then it gives a hook to use that data as the model in the web application on initial page load",
   "directories": {
     "doc": "doc",

--- a/tests/dummy/app/models/shoebox.js
+++ b/tests/dummy/app/models/shoebox.js
@@ -1,0 +1,3 @@
+import Model from 'ember-data/model';
+
+export default Model.extend({});


### PR DESCRIPTION
Previously, when fastboot-data-route was applied to a route that fetches a single model (e.g. via `store.findRecord()`), the data was being serialized and returned as an array with a single element. This was problematic because the route/controller expects the returned model to be a single object in these cases.